### PR TITLE
This fixes premature screen on during near events

### DIFF
--- a/src/co/hyper/proximityservice/DisplayStateHelper.java
+++ b/src/co/hyper/proximityservice/DisplayStateHelper.java
@@ -32,9 +32,6 @@ import android.util.Log;
 public class DisplayStateHelper implements DisplayListener {
      private static final String TAG = "DisplayStateListener";
      private static final boolean DEBUG = true;
-     // Do not let the sensor register for non call events such as doze
-     private static final String CALL_ST = "/proc/touchpanel/incall_status";
-
      private Context mcontext;
      private InfraredSensor mFakeProximity;
 
@@ -59,10 +56,6 @@ public class DisplayStateHelper implements DisplayListener {
        if (displayId == Display.DEFAULT_DISPLAY && isDefaultDisplayOff(mcontext)) {
            // register proximity
            if (DEBUG) Log.d(TAG, "Display OFF, Attempting to register proximity sensor");
-           if (!FileHelper.getFileValueAsBoolean(CALL_ST, false)) {
-               if (DEBUG) Log.d(TAG, "Not a call event,possible doze event bailing out");
-               return;
-           }
            mFakeProximity.enable();
        } else {
            // unregister proximity

--- a/src/co/hyper/proximityservice/InfraredSensor.java
+++ b/src/co/hyper/proximityservice/InfraredSensor.java
@@ -33,7 +33,7 @@ import android.os.Handler;
 public class InfraredSensor implements SensorEventListener {
     private static final boolean DEBUG = true;
     private static final String TAG = "InfraredSensor";
-    private static final int SENSORID = 33171027; //stk_st2x2x NonWakeup (High Accuracy)
+    private static final int SENSORID = 33171005; //stk_st2x2x Wakeup
     private static final int MASK_TIME = 150;
 
     private static final String PS_STATUS = "/proc/touchpanel/fd_enable";
@@ -51,14 +51,14 @@ public class InfraredSensor implements SensorEventListener {
         if (DEBUG) Log.d(TAG, "Intialising InfraDED sensor constructor");
         mContext = context;
         mSensorManager = mContext.getSystemService(SensorManager.class);
-        mSensor = mSensorManager.getDefaultSensor(SENSORID, false);
+        mSensor = mSensorManager.getDefaultSensor(SENSORID, true);
     }
 
     @Override
     public void onSensorChanged(SensorEvent event) {
         /* if we are here this means sensor live and is being used */
         sensorAlive = true;
-        if (event.values[0] <= 3.50f) {
+        if (event.values[0] <= 2.00f) {
             /* We don't need to do anything since the sensor is near */
             if (DEBUG) Log.d(TAG, "Near detected, Sending same in 50ms");
 

--- a/src/co/hyper/proximityservice/InfraredSensor.java
+++ b/src/co/hyper/proximityservice/InfraredSensor.java
@@ -28,13 +28,11 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
-import android.os.Handler;
 
 public class InfraredSensor implements SensorEventListener {
     private static final boolean DEBUG = true;
     private static final String TAG = "InfraredSensor";
     private static final int SENSORID = 33171005; //stk_st2x2x Wakeup
-    private static final int MASK_TIME = 150;
 
     private static final String PS_STATUS = "/proc/touchpanel/fd_enable";
     private static final String PS_MASK = "/proc/touchpanel/prox_mask";
@@ -58,7 +56,7 @@ public class InfraredSensor implements SensorEventListener {
     public void onSensorChanged(SensorEvent event) {
         /* if we are here this means sensor live and is being used */
         sensorAlive = true;
-        if (event.values[0] <= 2.00f) {
+        if (event.values[0] == 0) {
             /* We don't need to do anything since the sensor is near */
             if (DEBUG) Log.d(TAG, "Near detected, Sending same in 50ms");
 
@@ -72,12 +70,11 @@ public class InfraredSensor implements SensorEventListener {
              */
             if (flag) return;
 
-            (new Handler()).postDelayed(this::sendNear, MASK_TIME-100);
+            sendNear();
             return;
         }
         /* Let's do stuff ? */
-        if (DEBUG) Log.d(TAG, "Sending proximity far event in 150");
-        (new Handler()).postDelayed(this::sendFar, MASK_TIME);
+        sendFar();
     }
 
     @Override
@@ -90,7 +87,7 @@ public class InfraredSensor implements SensorEventListener {
             if (DEBUG) Log.d(TAG, "Enabling QTI Proximity Sensor fd_enable was 1");
             sensorAlive = true;
             flag = false; // Allow reporting near for initial case
-            mSensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_NORMAL);
+            mSensorManager.registerListener(this, mSensor, 50000);
         } else {
             if (DEBUG) Log.d(TAG, "Not a touchpanel proximity event");
             return;


### PR DESCRIPTION
Before this, it used to turn on screen unless the phone is kept very close to ear. It used to work a bit spotty when manually testing it by covering the top end of the screen by hand when there is gap between fingers. With this patch, it works on all conditions.

dumpsys sensorservice is attached to the commit history for reference.